### PR TITLE
Update PresetFormat to use renamed PresetVideoFormat

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,8 +2,10 @@ Changelog
 =========
 Next Release
 ------------
-:py:func:`vsfieldkit.prepare_nnedi3_chroma_upsampler` can now use the znedi3
-or nnedi3cl plugin in addition to plain nnedi3 as before.
+* :py:func:`vsfieldkit.prepare_nnedi3_chroma_upsampler` can now use the znedi3
+  or nnedi3cl plugin in addition to plain nnedi3 as before.
+* Add compatibility with VapourSynth>=63 Python wrapper, broken due to renamed
+  ``PresetVideoFormat`` enum.
 
 2.0.1
 -----

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -460,7 +460,7 @@ Repair
         If the clip to repair has been up-sampled for editing (e.g. from
         YUV420P8 to YUV422P16), pass in the original clip's format here
         so that correct assumptions are made for damage repair decisions.
-    :type original_format: PresetFormat, VideoFormat, VideoNode or int
+    :type original_format: PresetVideoFormat, VideoFormat, VideoNode or int
 
     :param bool restore_blank_detail:
         In rare cases where the black bars contain salvageable image data, this

--- a/vsfieldkit/kernels.py
+++ b/vsfieldkit/kernels.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional, Union
 
-from vapoursynth import (ColorFamily, Error, PresetFormat, VideoFormat,
+from vapoursynth import (ColorFamily, Error, PresetVideoFormat, VideoFormat,
                          VideoNode, core)
 
 from vsfieldkit.types import Resizer
@@ -76,7 +76,7 @@ def prepare_nnedi3_chroma_upsampler(
             
     def upsample_chroma_using_nnedi3(
         clip: VideoNode,
-        format: Union[VideoFormat, PresetFormat] = None,
+        format: Union[VideoFormat, PresetVideoFormat] = None,
         *resize_args,
         **resize_kwargs
     ) -> VideoNode:

--- a/vsfieldkit/kernels.py
+++ b/vsfieldkit/kernels.py
@@ -1,7 +1,11 @@
 from typing import Callable, Optional, Union
 
-from vapoursynth import (ColorFamily, Error, PresetVideoFormat, VideoFormat,
-                         VideoNode, core)
+from vapoursynth import ColorFamily, Error, VideoFormat, VideoNode, core
+
+try:
+    from vapoursynth import PresetVideoFormat
+except ImportError:
+    from vapoursynth import PresetFormat as PresetVideoFormat
 
 from vsfieldkit.types import Resizer
 from vsfieldkit.util import (annotate_bobbed_fields, convert_format_if_needed,

--- a/vsfieldkit/types.py
+++ b/vsfieldkit/types.py
@@ -3,7 +3,12 @@ from enum import Enum
 from fractions import Fraction
 from typing import Callable, Union
 
-from vapoursynth import PresetVideoFormat, VideoFormat, VideoNode
+from vapoursynth import VideoFormat, VideoNode
+
+try:
+    from vapoursynth import PresetVideoFormat
+except ImportError:
+    from vapoursynth import PresetFormat as PresetVideoFormat
 
 Factor = Union[int, float, Decimal, Fraction]
 

--- a/vsfieldkit/types.py
+++ b/vsfieldkit/types.py
@@ -3,11 +3,11 @@ from enum import Enum
 from fractions import Fraction
 from typing import Callable, Union
 
-from vapoursynth import PresetFormat, VideoFormat, VideoNode
+from vapoursynth import PresetVideoFormat, VideoFormat, VideoNode
 
 Factor = Union[int, float, Decimal, Fraction]
 
-FormatSpecifier = Union[PresetFormat, VideoFormat, VideoNode, int]
+FormatSpecifier = Union[PresetVideoFormat, VideoFormat, VideoNode, int]
 
 Resizer = Callable[..., VideoNode]
 """A function following the same signature as VapourSynth's built in


### PR DESCRIPTION
Was renamed in R63 I guess, https://github.com/vapoursynth/vapoursynth/commit/859a0606fcd094a146e42b1e2770474c57de75bc